### PR TITLE
Use correct separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -17,12 +17,12 @@ writeGPIOAB	KEYWORD2
 readGPIOAB	KEYWORD2
 
 
-pinMode      KEYWORD2
+pinMode	KEYWORD2
 
-digitalWrite KEYWORD2
-digitalRead KEYWORD2
-analogWrite KEYWORD2
-analogRead KEYWORD2
+digitalWrite	KEYWORD2
+digitalRead	KEYWORD2
+analogWrite	KEYWORD2
+analogRead	KEYWORD2
 
 #######################################
 # Constants (LITERAL1)


### PR DESCRIPTION
The Arduino IDE currently requires the use of a single true tab separator between the name and identifier. Without this tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords